### PR TITLE
use realpath instead of relpath

### DIFF
--- a/clang_format_check.py
+++ b/clang_format_check.py
@@ -140,7 +140,7 @@ def main():
         files = set()
         for pattern in args.file:
             for file in glob.iglob(pattern):
-                files.add(os.path.relpath(file))
+                files.add(os.path.realpath(file))
 
         file_list = list(files)
         print "Checking {} files...".format(len(file_list))


### PR DESCRIPTION
Otherwise cwd is '' if called from where the file is located
in replacementes_from_file: os.path.basename(file)